### PR TITLE
Fixed background spectrum generation and interpolation issue.

### DIFF
--- a/iris_snr_sim.py
+++ b/iris_snr_sim.py
@@ -573,7 +573,7 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, itime = 1.0,
 
         #bkgd = background_specs2(resolution*2.0, filter, convolve=True, simdir = simdir)
         bkgd = background_specs3(resolution*2.0, filter, convolve=True, simdir = simdir,
-                                 filteronly=True)
+                                 filteronly=False)
 
         ohspec = bkgd.backspecs[0,:]
         cospec = bkgd.backspecs[1,:]
@@ -600,7 +600,7 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, itime = 1.0,
         #print wave
         #print backwave
 
-        backtot_func = interpolate.interp1d(backwave,backtot)
+        backtot_func = interpolate.interp1d(backwave,backtot,fill_value='extrapolate')
         backtot = backtot_func(wave)
 
         #print


### PR DESCRIPTION
The filteronly keyword in background_specs caused large underestimation of the noise in the IFS mode, particularly in H and K band.  Removing the keyword results in an interpolation error due to very small differences in the wavelength generation between background_specs and the rest of the code, which is fixed by adding the line "fill_value='extrapolate'" to the interpolation function.  These changes make the ETC consistent with the IDL simulator (at least in so far as there are only minor discrepancies caused by differences in the interpolation functions).