### PR TITLE
Fixed aperture summation incorrect value.

### DIFF
--- a/iris_snr_sim.py
+++ b/iris_snr_sim.py
@@ -139,7 +139,7 @@ def IRIS_ETC(filter = "K", mag = 21.0, flambda=1.62e-19, itime = 1.0,
     #           calc - either "snr" or "exptime"
 
     #fixed radius 0.2 arc sec
-    radius=0.1
+    radius=0.2
     radius /= scale
     sat_limit=50000
     if spectrum.lower() == "vega":


### PR DESCRIPTION
Radius = 0.1 listed in code, radius should be 0.2 for the 0.4" aperture.